### PR TITLE
Pull request to make plugin work again and some minor changes

### DIFF
--- a/tfwearables.sp
+++ b/tfwearables.sp
@@ -11,7 +11,7 @@
 #pragma newdecls required // Force Transitional Syntax
 #pragma semicolon 1 // Force semicolon mode
 
-#define PLUGIN_VERSION "1.3"
+#define PLUGIN_VERSION "1.3.1"
 
 // REF: https://developer.valvesoftware.com/wiki/Entity_limit
 #define MAX_ENTITY_SIZE 4096

--- a/tfwearables.sp
+++ b/tfwearables.sp
@@ -1085,6 +1085,11 @@ void updateEffectsEarly(Database db, DBResultSet results, const char[] error, an
 
 // FetchWearables - Used to fetch all data that might be already stored for the player inside the database.
 void FetchWearables(int client, char[] steamid) {
+	
+    if (IsFakeClient(client)){ // We do not need this code to run when a bot joins the server, that is only a waste of resources, and sending queries unnecessarily to the database.
+       return;
+    }
+	
     int userid = GetClientUserId(client); // Pass through client userid to validate & update player data in handler.
     char buffer[256]; // Buffer used to store temporary values in FetchWearables
     char query[512]; // Buffer used to store queries sent to database.
@@ -1361,9 +1366,9 @@ public Action OnResupply(Event event, const char[] name, bool dontBroadcast) {
 
 public Action WearablesCommand(int client, int args) {
 	
-	if (client <= 0){
-		PrintToServer("[TF Wearables] This command is not available to the server console"); // Properly handle command for server console, instead of throwing an error.
-		return Plugin_Handled;
+    if (client <= 0){
+        PrintToServer("[TF2 Wearables] This command is not available to the server console"); // Properly handle command for server console, instead of throwing an error.
+        return Plugin_Handled;
 	}
 	
     if(!cEnabled.BoolValue) // If plugin is not enabled, do nothing.


### PR DESCRIPTION
Version 1.3.1 is a little bit different compared to 1.3:

* Fixed the plugin entirely refusing to load by removing the unnecessary tf2utils include. For some reason this dependency wouldn't work on my server causing this plugin to not work as well. The compiler did not complain about anything removing this include, so I assume this plugin does not need it.
* Fixed the plugin inserting bots to the database. Since bots are not going to make use of this plugin, it's a better practice to stop the code if a bot is detected. This update also prevents running SELECT queries when a bot joins the server, reducing the amount of unnecessary queries sent to the server by a little bit and also the code won't run unnecessarily for the bot.
* The plugin now handles it when you try to run the command in the server console, it prints a message instead of throwing an error.